### PR TITLE
Feat/vercel설정 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+    "rewrites": [
+      { "source": "/(.*)", "destination": "/" }
+    ]
+  }


### PR DESCRIPTION
리액트가 SPA (Single Page Application) 기반이라 vercel에서 다른 주소로 이동하지 못하는 문제가 있었습니다.(로컬에서는 vite 서버가 자동으로 처리해줍니다.) 그래서 설정 파일을 추가해 해당 문제를 해결했습니다.