### PR TITLE
Feature/ 열람 비밀번호 옵셔널로 인한 로직, ui 변경

### DIFF
--- a/src/pages/ReceiveLetter.tsx
+++ b/src/pages/ReceiveLetter.tsx
@@ -23,7 +23,10 @@ const MOCK = {
 
 export default function ReceiveLetter() {
   const navigate = useNavigate();
-  const [phase, setPhase] = useState<Phase>("password");
+  const hasPassword = true; // TODO : API 연동 후 교체
+  const [phase, setPhase] = useState<Phase>(
+    hasPassword ? "password" : "before",
+  );
   const [pw, setPw] = useState("");
   const [pwError, setPwError] = useState("");
 

--- a/src/pages/ShareLink.tsx
+++ b/src/pages/ShareLink.tsx
@@ -25,6 +25,8 @@ export default function ShareLink() {
   const now = new Date();
   const date = `${now.getFullYear()}년 ${String(now.getMonth() + 1).padStart(2, "0")}월 ${String(now.getDate()).padStart(2, "0")}일`;
 
+  const letterPassword = state?.letterPassword ?? "";
+
   return (
     <div
       className="min-h-screen flex flex-col"
@@ -105,34 +107,47 @@ export default function ShareLink() {
         />
 
         {/* 열람용 비밀번호: field 350x92 */}
-        <div className="w-full text-left mb-5">
-          <p
-            className="text-[12px] font-medium mb-2"
-            style={{
-              fontFamily: "var(--font-sans)",
-              color: "var(--color-rose)",
-            }}
-          >
-            🔒 열람용 비밀번호
-          </p>
-          <div
-            className="w-full px-4 py-[14px] rounded-[12px]"
-            style={{
-              background: "var(--color-rose-pale)",
-              border: "1px solid var(--color-rose-light)",
-            }}
-          >
-            <span
-              className="text-[16px]"
+        {letterPassword && (
+          <div className="w-full text-left mb-5">
+            <p
+              className="text-[12px] font-medium mb-2"
               style={{
                 fontFamily: "var(--font-sans)",
-                color: "var(--color-ink)",
+                color: "var(--color-rose)",
               }}
             >
-              {MOCK.password}
-            </span>
+              🔒 열람용 비밀번호
+            </p>
+            <div
+              className="w-full px-4 py-[14px] rounded-[12px] mb-2"
+              style={{
+                background: "var(--color-rose-pale)",
+                border: "1px solid var(--color-rose-light)",
+              }}
+            >
+              <span
+                className="text-[16px]"
+                style={{
+                  fontFamily: "var(--font-sans)",
+                  color: "var(--color-ink)",
+                }}
+              >
+                {MOCK.password}
+              </span>
+            </div>
+            <p
+              className="text-[14px] leading-[1.7] "
+              style={{
+                fontFamily: "var(--font-sans)",
+                color: "var(--color-ink-soft)",
+              }}
+            >
+              편지를 받는 분이 이 비밀번호를 입력해야 해요.
+              <br />
+              비밀번호와 함께 편지를 전달해 주세요.
+            </p>
           </div>
-        </div>
+        )}
       </div>
       <div className="flex-shrink-0 px-5 py-4 ">
         <KakaoShareButton

--- a/src/pages/WriteLetter.tsx
+++ b/src/pages/WriteLetter.tsx
@@ -456,7 +456,7 @@ export default function WriteLetter() {
             </>
           )}
 
-          {/* ── STEP 4: 보안 설정 ── */}
+          {/* ── STEP 4: 비밀번호 ── */}
           {step === 4 && (
             <>
               <h1
@@ -475,9 +475,9 @@ export default function WriteLetter() {
               {/* 비밀번호 입력 — 피그마: 숫자만, 마스킹 안함 */}
               <div className="flex flex-col gap-4 mb-4">
                 <Input
-                  label="열람 비밀번호"
+                  label="열람 비밀번호(선택)"
                   required
-                  placeholder="숫자를 입력해주세요"
+                  placeholder="숫자를 입력해주세요(선택)"
                   inputMode="numeric"
                   type="text"
                   value={form.letterPassword}

--- a/src/pages/WriteLetter.tsx
+++ b/src/pages/WriteLetter.tsx
@@ -50,7 +50,7 @@ const STEPS = [
   { label: "기본 정보" },
   { label: "편지 작성" },
   { label: "편지지 선택" },
-  { label: "보안 설정" },
+  { label: "비밀번호" },
 ];
 
 export default function WriteLetter() {
@@ -467,9 +467,9 @@ export default function WriteLetter() {
                   fontSize: 24,
                 }}
               >
-                열람 비밀번호를
+                둘만의 편지로 만들고 싶다면
                 <br />
-                설정해주세요
+                비밀번호를 설정해보세요
               </h1>
 
               {/* 비밀번호 입력 — 피그마: 숫자만, 마스킹 안함 */}
@@ -496,9 +496,9 @@ export default function WriteLetter() {
                   color: "var(--color-rose)",
                 }}
               >
-                🔒 비밀번호는 암호화되어 저장되며 패킷팀도 알 수 없어요.
+                🔒 비밀번호는 받는 분에게도 꼭 알려주세요.
                 <br />
-                비밀번호를 잊으면 복구가 불가능하니 꼭 기억해주세요.
+                잊어버리면 복구가 어려워요.
               </div>
             </>
           )}

--- a/src/pages/WriteLetter.tsx
+++ b/src/pages/WriteLetter.tsx
@@ -42,15 +42,15 @@ const INITIAL_FORM: LetterFormData = {
   content: "",
   originalContent: "",
   tone: null,
-  password: "",
+  letterPassword: "",
   theme: 1,
 };
 
 const STEPS = [
   { label: "기본 정보" },
   { label: "편지 작성" },
-  { label: "보안 설정" },
   { label: "편지지 선택" },
+  { label: "보안 설정" },
 ];
 
 export default function WriteLetter() {
@@ -61,7 +61,6 @@ export default function WriteLetter() {
   // ──────────────────────────────────────────────────────────
 
   const scrollRef = useRef<HTMLDivElement>(null);
-
   const scrollToTop = () => scrollRef.current?.scrollTo({ top: 0 });
 
   const goNext = () => {
@@ -81,7 +80,6 @@ export default function WriteLetter() {
   const step1Valid =
     form.to.trim() !== "" && form.from.trim() !== "" && form.keyword !== null;
   const step2Valid = form.content.trim() !== "";
-  const step3Valid = form.password.trim() !== "";
 
   // 스텝 상태
   const stepBarSteps = STEPS.map((s, i) => ({
@@ -356,54 +354,8 @@ export default function WriteLetter() {
             </>
           )}
 
-          {/* ── STEP 3: 보안 설정 ── */}
+          {/* ── STEP 3: 편지지 선택 ── */}
           {step === 3 && (
-            <>
-              <h1
-                className="font-bold leading-[1.3] tracking-[-0.02em] mb-5"
-                style={{
-                  fontFamily: "var(--font-serif)",
-                  color: "var(--color-ink)",
-                  fontSize: 24,
-                }}
-              >
-                열람 비밀번호를
-                <br />
-                설정해주세요
-              </h1>
-
-              {/* 비밀번호 입력 — 피그마: 숫자만, 마스킹 안함 */}
-              <div className="flex flex-col gap-4 mb-4">
-                <Input
-                  label="열람 비밀번호"
-                  required
-                  placeholder="숫자를 입력해주세요"
-                  inputMode="numeric"
-                  type="text"
-                  value={form.password}
-                  onChange={(e) => {
-                    const val = e.target.value.replace(/[^0-9]/g, "");
-                    setForm((p) => ({ ...p, password: val }));
-                  }}
-                />
-              </div>
-
-              <p
-                className="text-[14px] leading-[1.7] mb-6"
-                style={{
-                  fontFamily: "var(--font-sans)",
-                  color: "var(--color-ink-soft)",
-                }}
-              >
-                편지를 받는 분이 이 비밀번호를 입력해야 해요.
-                <br />
-                비밀번호와 함께 편지를 전달해 주세요.
-              </p>
-            </>
-          )}
-
-          {/* ── STEP 4: 편지지 선택 ── */}
-          {step === 4 && (
             <>
               <h1
                 className="font-bold leading-[1.3] tracking-[-0.02em] mb-5"
@@ -503,6 +455,53 @@ export default function WriteLetter() {
               />
             </>
           )}
+
+          {/* ── STEP 4: 보안 설정 ── */}
+          {step === 4 && (
+            <>
+              <h1
+                className="font-bold leading-[1.3] tracking-[-0.02em] mb-5"
+                style={{
+                  fontFamily: "var(--font-serif)",
+                  color: "var(--color-ink)",
+                  fontSize: 24,
+                }}
+              >
+                열람 비밀번호를
+                <br />
+                설정해주세요
+              </h1>
+
+              {/* 비밀번호 입력 — 피그마: 숫자만, 마스킹 안함 */}
+              <div className="flex flex-col gap-4 mb-4">
+                <Input
+                  label="열람 비밀번호"
+                  required
+                  placeholder="숫자를 입력해주세요"
+                  inputMode="numeric"
+                  type="text"
+                  value={form.letterPassword}
+                  onChange={(e) => {
+                    const val = e.target.value.replace(/[^0-9]/g, "");
+                    setForm((p) => ({ ...p, letterPassword: val }));
+                  }}
+                />
+              </div>
+
+              <div
+                className="px-4 py-3 my-3 rounded-[10px] text-[12px] text-center font-medium leading-[1.7]"
+                style={{
+                  background: "var(--color-rose-pale)",
+                  fontFamily: "var(--font-sans)",
+                  color: "var(--color-rose)",
+                }}
+              >
+                🔒 비밀번호는 암호화되어 저장되며 패킷팀도 알 수 없어요.
+                <br />
+                비밀번호를 잊으면 복구가 불가능하니 꼭 기억해주세요.
+              </div>
+            </>
+          )}
         </div>
       </div>
 
@@ -531,55 +530,43 @@ export default function WriteLetter() {
           </Button>
         )}
         {step === 3 && (
-          <>
-            <div
-              className="px-4 py-3 my-3 rounded-[10px] text-[12px] text-center font-medium leading-[1.7]"
-              style={{
-                background: "var(--color-rose-pale)",
-                fontFamily: "var(--font-sans)",
-                color: "var(--color-rose)",
-              }}
-            >
-              🔒 비밀번호는 암호화되어 저장되며 패킷팀도 알 수 없어요.
-              <br />
-              비밀번호를 잊으면 복구가 불가능하니 꼭 기억해주세요.
-            </div>
-            <Button
-              variant="primary"
-              fullWidth
-              style={{ height: 54, fontSize: 18, borderRadius: 12 }}
-              disabled={!step3Valid}
-              onClick={goNext}
-            >
-              다음
-            </Button>
-          </>
-        )}
-        {step === 4 && (
           <Button
             variant="primary"
             fullWidth
             style={{ height: 54, fontSize: 18, borderRadius: 12 }}
-            onClick={() => {
-              // TODO: POST /letters API 연동
-              navigate("/share", {
-                state: {
-                  theme: form.theme,
-                  to: form.to,
-                  from: form.from,
-                  content: form.content,
-                  date: new Date().toLocaleDateString("ko-KR", {
-                    year: "numeric",
-                    month: "2-digit",
-                    day: "2-digit",
-                  }),
-                  // TODO : password는 API 연동 후 서버에서 처리
-                },
-              });
-            }}
+            onClick={goNext}
           >
-            편지 완성하기
+            다음
           </Button>
+        )}
+        {step === 4 && (
+          <>
+            <Button
+              variant="primary"
+              fullWidth
+              style={{ height: 54, fontSize: 18, borderRadius: 12 }}
+              onClick={() => {
+                // TODO: POST /letters API 연동
+                navigate("/share", {
+                  state: {
+                    theme: form.theme,
+                    to: form.to,
+                    from: form.from,
+                    content: form.content,
+                    date: new Date().toLocaleDateString("ko-KR", {
+                      year: "numeric",
+                      month: "2-digit",
+                      day: "2-digit",
+                    }),
+                    letterPassword: form.letterPassword,
+                    // TODO : password는 API 연동 후 서버에서 처리
+                  },
+                });
+              }}
+            >
+              편지 완성하기
+            </Button>
+          </>
         )}
       </div>
     </div>

--- a/src/shared/schemas/letterSchema.ts
+++ b/src/shared/schemas/letterSchema.ts
@@ -12,7 +12,7 @@ export interface LetterFormData {
   content: string;
   originalContent: string; // AI 적용 직전 원본 내용 (원본 복구용)
   tone: LetterTone | null;
-  password: string; // 열람 비밀번호
+  letterPassword?: string; // 열람 비밀번호
   theme: LetterTheme;
 }
 


### PR DESCRIPTION
## 작업 내용
- #21 

### 플로우 수정
- 기존 : 편지작성 시 3. 보안 설정 > 4. 편지지 선택
- 변경 :3. 편지지 선택 > 4.보안 설정
<img width="684" height="577" alt="스크린샷 2026-04-30 오후 6 55 06" src="https://github.com/user-attachments/assets/502cd151-a057-4ecf-8bea-ea60bce2f760" />


### ui 수정
- 편지작성 보안 설정의 일부 문구를 링크 생성 화면으로 이동
<img width="266" height="562" alt="스크린샷 2026-04-30 오후 7 16 08" src="https://github.com/user-attachments/assets/dac023f7-d852-41b0-bf15-450a59dea1e1" />


### 분기 처리
- 비밀번호 유무 분기에 따른 처리
- 링크 생성 : 설정된 열람 비밀번호 노출 분기
- 편지 수신 : 열람 비밀번호 유무에 따른 비밀번호 입력 페이지 분기 처리

Closes #21 