### PR TITLE
fix: 카카오 로그인 인증 코드 롤백

### DIFF
--- a/src/shared/components/ui/KakaoLoginButton.tsx
+++ b/src/shared/components/ui/KakaoLoginButton.tsx
@@ -67,7 +67,7 @@ export default function KakaoLoginButton({
 
     const queryString = new URLSearchParams({
       client_id: import.meta.env.VITE_KAKAO_REST_API_KEY,
-      redirect_uri: `${originUrl}/api/proxy/api/auth/kakao/callback`,
+      redirect_uri: `${originUrl}${import.meta.env.VITE_KAKAO_BASE_URL}/api/auth/kakao/callback`,
       response_type: "code",
       state: nanoId,
     }).toString();


### PR DESCRIPTION
카카오 로그인 시 콜백 실패로 빈 창이 뜨는 이슈 해결하려 했으나
동일한 이슈 발생하여 기존 코드로 롤백